### PR TITLE
fix: make SSH private key import pick files on Xiaomi/MIUI

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         applicationId = "com.example.dsh"
         minSdk = 24
         targetSdk = 28
-        versionCode = 4
-        versionName = "0.0.4"
+        versionCode = 5
+        versionName = "0.0.5"
         ndk {
             abiFilters += "arm64-v8a"
         }

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- 部分国产 ROM（如小米 MIUI）的系统文件选择器要求调用方持有存储读取权限才会列出本地文件，
+         因此在 Android 12L 及以下声明并在导入 SSH 私钥前运行时申请；Android 13+ 由 SAF 覆盖，无需此权限。 -->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/androidApp/src/main/java/com/example/dsh/KuiklyRenderActivity.kt
+++ b/androidApp/src/main/java/com/example/dsh/KuiklyRenderActivity.kt
@@ -76,6 +76,11 @@ class KuiklyRenderActivity : AppCompatActivity(), KuiklyRenderViewBaseDelegatorD
         KRDshRelayModule.dispatchActivityResult(requestCode, resultCode, data)
     }
 
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        KRBridgeModule.dispatchRequestPermissionsResult(requestCode, permissions, grantResults)
+    }
+
     override fun onResume() {
         super.onResume()
         kuiklyRenderViewDelegator.onResume()

--- a/androidApp/src/main/java/com/example/dsh/module/KRBridgeModule.kt
+++ b/androidApp/src/main/java/com/example/dsh/module/KRBridgeModule.kt
@@ -1,9 +1,12 @@
 package com.example.dsh.module
 
+import android.Manifest
+import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.graphics.Color
 import android.os.Build
@@ -227,22 +230,89 @@ class KRBridgeModule : KuiklyRenderBaseModule() {
 
     private fun pickSshKey(callback: KuiklyRenderCallback?) {
         sshKeyCallback = callback
-        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-            addCategory(Intent.CATEGORY_OPENABLE)
-            type = "application/octet-stream"
+        val act = activity ?: run {
+            callback?.invoke(mapOf("uri" to ""))
+            return
         }
-        activity?.startActivityForResult(intent, REQUEST_SSH_KEY)
+        // SAF 选择器本身不需要调用方持有存储权限，但小米/MIUI 等国产 ROM 的文件选择器
+        // 在调用方未获得存储读取权限时不会列出本地文件（列表为空、没有可选中文件），也
+        // 不会替调用方弹出授权框。因此在 Android 12L 及以下先申请一次读取权限再打开选择器。
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU &&
+            act.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED
+        ) {
+            act.requestPermissions(
+                arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE),
+                REQUEST_SSH_KEY_PERMISSION,
+            )
+            return
+        }
+        launchSshKeyPicker()
+    }
+
+    private fun launchSshKeyPicker() {
+        val act = activity
+        if (act == null) {
+            sshKeyCallback?.invoke(mapOf("uri" to ""))
+            sshKeyCallback = null
+            return
+        }
+        // 私钥可能是 id_rsa 这类无扩展名文件，也可能是 *.pem / *.key / *.txt。
+        // 用 application/octet-stream 之类的具体 MIME 过滤时，小米/MIUI 的 DocumentsUI
+        // 会把不匹配的文件置灰或直接过滤掉，表现为“没有任何文件可以选中”。这里放开为
+        // */*（私钥是否合法由导入后的解析校验负责），保证任何来源的文件都可选。
+        val picker = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "*/*"
+        }
+        try {
+            act.startActivityForResult(picker, REQUEST_SSH_KEY)
+        } catch (e: ActivityNotFoundException) {
+            // 个别 ROM 缺少 DocumentsUI（ACTION_OPEN_DOCUMENT 无人处理），退回老式选择器。
+            Log.w("KuiklyRender", "ACTION_OPEN_DOCUMENT has no handler, falling back to ACTION_GET_CONTENT", e)
+            val fallback = Intent(Intent.ACTION_GET_CONTENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = "*/*"
+            }
+            try {
+                act.startActivityForResult(fallback, REQUEST_SSH_KEY)
+            } catch (e2: ActivityNotFoundException) {
+                Log.w("KuiklyRender", "no system file picker available", e2)
+                Toast.makeText(KRApplication.application, "无法打开文件选择器，请检查系统文件管理应用", Toast.LENGTH_SHORT).show()
+                sshKeyCallback?.invoke(mapOf("uri" to ""))
+                sshKeyCallback = null
+            }
+        }
+    }
+
+    private fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        if (requestCode != REQUEST_SSH_KEY_PERMISSION) return
+        val granted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            Toast.makeText(
+                KRApplication.application,
+                "未授予存储读取权限：若文件选择器中看不到文件，请在系统设置中允许“文件/存储”访问后重试",
+                Toast.LENGTH_LONG,
+            ).show()
+        }
+        // 授权与否都继续打开系统文件选择器（Android 原生 SAF 不依赖该权限）。
+        launchSshKeyPicker()
     }
 
     private fun importSshKey(params: String?, callback: KuiklyRenderCallback?) {
         val uri = Uri.parse(JSONObject(params ?: "{}").optString("uri"))
-        val bytes = context?.contentResolver?.openInputStream(uri)?.use { it.readBytes() }
+        val bytes = runCatching {
+            context?.contentResolver?.openInputStream(uri)?.use { it.readBytes() }
+        }.getOrNull()
         if (bytes == null) {
             callback?.invoke(mapOf("ok" to false, "message" to "无法读取 SSH 私钥"))
             return
         }
-        val keyId = DshSshKeyStore(requireNotNull(context)).importBytes("ssh-key", bytes)
+        val keyId = runCatching { DshSshKeyStore(requireNotNull(context)).importBytes("ssh-key", bytes) }.getOrNull()
         bytes.fill(0)
+        if (keyId == null) {
+            callback?.invoke(mapOf("ok" to false, "message" to "无法导入 SSH 私钥"))
+            return
+        }
         callback?.invoke(mapOf("ok" to true, "keyId" to keyId))
     }
 
@@ -291,10 +361,15 @@ class KRBridgeModule : KuiklyRenderBaseModule() {
     companion object {
         const val MODULE_NAME = "HRBridgeModule"
         const val REQUEST_SSH_KEY = 4091
+        const val REQUEST_SSH_KEY_PERMISSION = 4092
         private var activeInstance: KRBridgeModule? = null
 
         fun dispatchActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
             activeInstance?.onActivityResult(requestCode, resultCode, data)
+        }
+
+        fun dispatchRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+            activeInstance?.onRequestPermissionsResult(requestCode, permissions, grantResults)
         }
     }
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.4</string>
+	<string>0.0.5</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
## 问题

小米（MIUI）手机上「导入 SSH 私钥」时，系统文件选择器里**没有任何文件可以选中**，且**不会弹出文件读取权限申请**。其他机型正常。

## 根因

1. 选择器用 `ACTION_OPEN_DOCUMENT` + `type = "application/octet-stream"` 过滤。私钥常是 `id_rsa`（无扩展名）或 `.pem` / `.key` / `.txt`，MIUI 的 DocumentsUI 按扩展名推断 MIME，不匹配的文件会被置灰/过滤掉 → 看起来"没有可选中文件"（AOSP 机型无此差异，故仅小米复现）。
2. App 从未声明/申请 `READ_EXTERNAL_STORAGE`（`targetSdk=28`），而小米的文件选择器在调用方无存储读取权限时不会列出本地文件，也不会替调用方弹授权框。

## 改动（3 个文件）

- `androidApp/src/main/AndroidManifest.xml`：声明 `READ_EXTERNAL_STORAGE`（`maxSdkVersion="32"`）。
- `androidApp/src/main/java/com/example/dsh/module/KRBridgeModule.kt`：
  - 选择器 MIME 放开为 `*/*`（私钥合法性由导入后解析校验把关）；
  - Android 12L 及以下打开选择器前先运行时申请存储权限（授权与否都会继续，拒绝时 Toast 引导去系统设置）；
  - `ActivityNotFoundException` 时回退 `ACTION_GET_CONTENT`（个别 ROM 缺 DocumentsUI）；
  - `importSshKey` 读取/导入加异常保护，不再崩溃。
- `androidApp/src/main/java/com/example/dsh/KuiklyRenderActivity.kt`：转发 `onRequestPermissionsResult` 到桥接模块。

第二个提交把 Android/iOS 版本号升到 0.0.5（沿用仓库"修复即发版"的习惯）；如想自行编排发版，可只取第一个提交。

## 验证

- 代码已在 fork（upliu/deepseek-harness-mobile）上作为 v0.0.5 构建发布，CI 通过、APK 产物正常；
- 建议在小米真机回归：设置页「导入私钥」→ 出现权限弹窗 → 授权后 `id_rsa`/`.pem`/`.key` 均可选中。