### PR TITLE
fix(chat): 聊天输入框支持多行输入，并封顶最大高度以避免超出屏幕

### DIFF
--- a/shared/src/commonMain/kotlin/com/example/dsh/dsh/DshHomeConversation.kt
+++ b/shared/src/commonMain/kotlin/com/example/dsh/dsh/DshHomeConversation.kt
@@ -10,8 +10,8 @@ import com.tencent.kuikly.core.directives.vforLazy
 import com.tencent.kuikly.core.layout.FlexAlign
 import com.tencent.kuikly.core.reactive.collection.ObservableList
 import com.tencent.kuikly.core.views.Image
-import com.tencent.kuikly.core.views.Input
-import com.tencent.kuikly.core.views.InputView
+import com.tencent.kuikly.core.views.TextArea
+import com.tencent.kuikly.core.views.TextAreaView
 import com.tencent.kuikly.core.views.KeyboardParams
 import com.tencent.kuikly.core.views.List
 import com.tencent.kuikly.core.views.ListView
@@ -134,7 +134,7 @@ internal fun ViewContainer<*, *>.DshConversation(
     keyboardHeight: () -> Float,
     stopButtonVisible: () -> Boolean,
     keyboardAnimation: () -> Animation,
-    inputRef: (com.tencent.kuikly.core.base.ViewRef<InputView>) -> Unit,
+    inputRef: (com.tencent.kuikly.core.base.ViewRef<TextAreaView>) -> Unit,
     onInputFocusChange: (Boolean) -> Unit,
     onDraftChange: (String) -> Unit,
     onKeyboardHeightChange: (KeyboardParams) -> Unit,
@@ -460,10 +460,11 @@ internal fun ViewContainer<*, *>.DshConversation(
                         }
                     }
                 }
-            Input {
+            TextArea {
                 ref { inputRef(it) }
                 attr {
-                    height(58f)
+                    minHeight(58f)
+                    maxHeight(120f)
                     backgroundColor(Color(0x00FFFFFF))
                     fontSize(15f)
                     color(Color(0xFF28323C))
@@ -476,7 +477,6 @@ internal fun ViewContainer<*, *>.DshConversation(
                         },
                     )
                     placeholderColor(Color(0xFF91A0AA))
-                    returnKeyTypeSend()
                     editable(!voiceActive())
                 }
                 event {
@@ -487,7 +487,6 @@ internal fun ViewContainer<*, *>.DshConversation(
                         onInputFocusChange(false)
                         onKeyboardHeightChange(KeyboardParams(0f, 0.24f))
                     }
-                    inputReturn { onSend() }
                 }
             }
 

--- a/shared/src/commonMain/kotlin/com/example/dsh/dsh/DshHomeConversation.kt
+++ b/shared/src/commonMain/kotlin/com/example/dsh/dsh/DshHomeConversation.kt
@@ -407,7 +407,6 @@ internal fun ViewContainer<*, *>.DshConversation(
         }
             View {
                 attr {
-                    height(COMPOSER_HEIGHT)
                     width(availableWidth)
                     flexDirectionColumn()
                     padding(12f, 14f, 12f, 14f)

--- a/shared/src/commonMain/kotlin/com/example/dsh/dsh/DshHomePage.kt
+++ b/shared/src/commonMain/kotlin/com/example/dsh/dsh/DshHomePage.kt
@@ -14,6 +14,7 @@ import com.tencent.kuikly.core.views.Input
 import com.tencent.kuikly.core.views.InputView
 import com.tencent.kuikly.core.views.Modal
 import com.tencent.kuikly.core.views.Text
+import com.tencent.kuikly.core.views.TextAreaView
 import com.tencent.kuikly.core.views.View
 import com.tencent.kuikly.core.module.NetworkModule
 import com.tencent.kuikly.core.module.RouterModule
@@ -101,7 +102,7 @@ internal class DshHomePage : BasePager() {
     private var attachmentMenuVisible by observable(false)
     private var voiceActive by observable(false)
     private var topBarRef: ViewRef<com.tencent.kuikly.core.views.DivView>? = null
-    private var inputView: InputView? = null
+    private var inputView: TextAreaView? = null
     private var apiKeyInputView: InputView? = null
     private var streamHandle: DshStreamHandle? = null
     private val messageScrollerRefs = mutableMapOf<String, ViewRef<ListView<*, *>>>()

--- a/shared/src/commonMain/kotlin/com/example/dsh/dsh/DshHomeUi.kt
+++ b/shared/src/commonMain/kotlin/com/example/dsh/dsh/DshHomeUi.kt
@@ -49,6 +49,5 @@ internal fun topBarConnectingText(label: String): String {
     return value
 }
 
-internal const val COMPOSER_HEIGHT = 142f
 internal const val CHAT_INITIAL_RENDER_COUNT = 48
 internal const val CHAT_MAX_RENDERED_MESSAGES = 128


### PR DESCRIPTION
## 问题背景

移动端聊天页的输入框无法录入多行内容：

- **无法换行输入**：聊天输入框使用 Kuikly 的 `Input` 组件，它是**单行**输入框，长文本不自动换行，回车即发送，无法录入多行内容，与桌面端输入体验不一致，用户无法正常浏览自己的输入。

> 补充：将输入框替换为 `TextArea` 后需配套处理高度上限——若输入卡容器高度被写死，长文本会把容器撑出屏幕。本次一并改为由 `TextArea` 的 `maxHeight` 封顶，超出部分在输入框内滚动。

## 根因分析

1. **`Input` 是单行组件**：Kuikly 官方文档将 `Input` 明确定义为「单行输入框」，不支持自动换行。多行输入应使用 `TextArea`。
2. **高度配套处理**：聊天输入卡容器原本被写为固定 `height(COMPOSER_HEIGHT)`（`142f`）。若保留该固定高度，多行文本会把容器撑出屏幕。本次移除固定高度，让容器随 `TextArea` 内容自适应，由 `maxHeight(120f)` 封顶（约 6 行），超出的内容在输入框内滚动。

<img width="1421" height="652" alt="kuikly-input-vs-textarea" src="https://github.com/user-attachments/assets/48a673dc-f739-4fa2-8c5a-5794a3e87b39" />



## 改动内容

共 2 个提交、3 个文件，全部位于 `shared/src/commonMain`（KMP 公共代码）：

| 文件 | 内容 |
| --- | --- |
| `DshHomeConversation.kt` | 输入框由 `Input` 替换为 `TextArea`；移除 `returnKeyTypeSend()` 与回车发送事件；移除输入卡容器固定高度，改为随内容自适应 |
| `DshHomePage.kt` | 输入框引用类型由 `InputView?` 调整为 `TextAreaView?`，补充导入 |
| `DshHomeUi.kt` | 删除已无引用的常量 `COMPOSER_HEIGHT` |

> **行为变化说明**：回车键不再发送消息（需点击发送按钮）。保留单行回车发送需要额外的按键修饰处理（如 Shift+回车换行），不在本次范围内。

## 测试计划

在 Android 12 模拟器（1080×2274）上验证：

| # | 场景 | 预期 | 结果 |
| --- | --- | --- | --- |
| 1 | 单行输入短消息 | 保持单行高度，正常聚焦输入 | ✅ 通过 |
| 2 | 输入长文本、超过可视宽度 | 自动换行，高度随行数增长 | ✅ 通过 |
| 3 | 文本超过约 6 行 | 高度封顶（maxHeight），不再增高 | ✅ 通过 |
| 4 | 超五行后继续输入 | 尾部裁剪、输入框内部滚动 | ✅ 通过 |
| 5 | 键盘弹出态超六行 | 不超出键盘上方可视区域 | ✅ 通过 |
| 6 | 键盘收起态保留超六行文本 | 保持封顶高度、锚定底部，不挤屏幕 | ✅ 通过 |
| 7 | 回车按键 | 仅换行，不再发送 | ✅ 通过 |
| 8 | 点击发送按钮 | 正常发送、内容清空 | ✅ 通过 |


| 修复前 | 修复后 |
| --- | --- |
| ![修复前：输入框为单行，长文本不换行](https://github.com/user-attachments/assets/9895d101-1542-4009-ac2e-b5118dbd6630) | ![修复后：TextArea 多行输入，超五行后高度封顶、内部滚动](https://github.com/user-attachments/assets/0c10b64d-066b-48d4-ad1c-69a430563ab8) |

## 环境信息
- Android 模拟器：Android 12 (API 31) · 1080×2274
- 构建：`./gradlew :androidApp:installDebug`
- 依赖：Kuikly 2.24.0 · Kotlin 2.1.21 · AGP 8.4.0